### PR TITLE
Workaround for showing protected casts

### DIFF
--- a/TPerl_ArcaneBar/TPerl_ArcaneBar.lua
+++ b/TPerl_ArcaneBar/TPerl_ArcaneBar.lua
@@ -470,6 +470,12 @@ function TPerl_ArcaneBar_OnEvent(self, event, unit, ...)
 		self.castID = castID
 		self.barParentName:Hide()
 		self.barSpark:Show()
+
+		if(type(notInterruptible) == "boolean") then
+			-- Allowed to be called using the secret value
+			self.shield:SetAlphaFromBoolean(notInterruptible)
+		end
+
 		if (not startTime or not endTime) then
 			-- Midnight/Retail: some channel casts may not provide usable timing info (or values may be blocked/secret).
 			-- Try to estimate a duration from spellID so we can still show a progressing bar (one direction).
@@ -583,6 +589,12 @@ function TPerl_ArcaneBar_OnEvent(self, event, unit, ...)
 				self:Hide()
 				return
 			end
+
+			if(type(notInterruptible) == "boolean") then
+				-- Allowed to be called using the secret value
+				self.shield:SetAlphaFromBoolean(notInterruptible)
+			end
+
 			local sid = spellID
 			if (not sid or (canaccessvalue and not TPerl_AB_CanAccess(sid))) then
 				sid = self.spellID or eventSpellID
@@ -633,6 +645,11 @@ function TPerl_ArcaneBar_OnEvent(self, event, unit, ...)
 		end
 		self.spellID = sid
 		self.estimated = nil
+
+		if(type(notInterruptible) == "boolean") then
+			-- Allowed to be called using the secret value
+			self.shield:SetAlphaFromBoolean(notInterruptible)
+		end
 
 		self:SetStatusBarColor(barColours.channel.r, barColours.channel.g, barColours.channel.b, conf.transparency.frame)
 		self.barSpark:Show()

--- a/TPerl_ArcaneBar/TPerl_ArcaneBar.xml
+++ b/TPerl_ArcaneBar/TPerl_ArcaneBar.xml
@@ -19,6 +19,18 @@ C:\Projects\WoW\Bin\Interface\FrameXML\UI.xsd">
 						</Anchor>
 					</Anchors>
 				</Texture>
+				<Texture name="$parentshield" file="Interface\GroupFrame\UI-Group-MainTankIcon">
+					<Size>
+						<AbsDimension x="16" y="16"/>
+					</Size>
+					<Anchors>
+						<Anchor point="LEFT">
+							<Offset>
+								<AbsDimension x="0" y="0"/>
+							</Offset>
+						</Anchor>
+					</Anchors>
+				</Texture>
 				<FontString name="$parentcastTimeText" inherits="GameFontHighlight" hidden="true">
 					<Anchors>
 						<Anchor point="LEFT" relativePoint="RIGHT">


### PR DESCRIPTION
It might just be my client, but protected casts were missing the shield icon.  This is just a quick workaround that I'm using locally - there are probably better ways to do it.  But since you are working on TPerl2, I figured I could provide a PR for the current TPerl.